### PR TITLE
Column and row move commands should not use shift

### DIFF
--- a/content_scripts/commands.js
+++ b/content_scripts/commands.js
@@ -94,10 +94,10 @@ Commands = {
       "l": "moveRight",
 
       // Row & column movement
-      "<C-J>": "moveRowsDown",
-      "<C-K>": "moveRowsUp",
-      "<C-H>": "moveColumnsLeft",
-      "<C-L>": "moveColumnsRight",
+      "<C-j>": "moveRowsDown",
+      "<C-k>": "moveRowsUp",
+      "<C-h>": "moveColumnsLeft",
+      "<C-l>": "moveColumnsRight",
 
       // TODO(philc): remove this because it's custom to my configuration
       "BACKSPACE": "moveColumnsLeft",


### PR DESCRIPTION
I noticed that move* commands are registered with upper H, J, K and L, where should be lower case.
Anyway, I love this extension. Thanks a lot!