### PR TITLE
Change normal and visual mode behavior more strict

### DIFF
--- a/content_scripts/commands.js
+++ b/content_scripts/commands.js
@@ -92,6 +92,10 @@ Commands = {
       "j": "moveDown",
       "h": "moveLeft",
       "l": "moveRight",
+      "up": "moveUp",
+      "down": "moveDown",
+      "left": "moveLeft",
+      "right": "moveRight",
 
       // Row & column movement
       "<C-J>": "moveRowsDown",

--- a/content_scripts/ui.js
+++ b/content_scripts/ui.js
@@ -231,7 +231,20 @@ UI = {
         this.keyQueue = [];
         this.cancelEvent(e);
         Commands.commands[commandName].fn();
+        return;
       }
+    }
+
+    // Cancel the event if the mode matches "normal" or "visual*",
+    // to prevent accidentally input an unassigned character like "w" or "b".
+    // Ensure that the key is not pressed with ctrl or meta,
+    // not to mask Google Sheets' default shortcuts such as ⌘-F.
+    if (
+      !e.ctrlKey &&
+      !e.metaKey &&
+      ["normal", "visual", "visualLine", "visualColumn"].includes(this.mode)
+    ) {
+      this.cancelEvent(e);
     }
   },
 


### PR DESCRIPTION
It changes normal and visual mode behavior to cancel all the unassigned characters, to prevent accidentally input an unassigned(but exists in vim) character like "w" or "b". I thought no-op is better than accidental input.
It does not cancel a key event if the key is pressed with ctrl or meta, not to mask Google Sheets' default shortcuts such as ⌘-F.
It also adds explicit arrow key mappings to prevent canceling them because of the above change.