### PR TITLE
Move to the beginning of the line before editing when opening a row

### DIFF
--- a/content_scripts/sheet_actions.js
+++ b/content_scripts/sheet_actions.js
@@ -265,11 +265,13 @@ SheetActions = {
   // Creates a row below and begins editing it.
   openRowBelow() {
     this.clickMenu(this.menuItems.rowBelow);
+    UI.typeKey(KeyboardUtils.keyCodes.home);
     UI.typeKey(KeyboardUtils.keyCodes.enter);
   },
 
   openRowAbove() {
     this.clickMenu(this.menuItems.rowAbove);
+    UI.typeKey(KeyboardUtils.keyCodes.home);
     UI.typeKey(KeyboardUtils.keyCodes.enter);
   },
 


### PR DESCRIPTION
It changes the behavior of `o` and `O` to edit the beginning cell of a new row.
Mimicking Vim's behavior, I felt that's more natural, but it might depend on a personal preference.
Feel free to request changes.

Thanks.