### PR TITLE
Add more cell colors to formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,104 @@ spirit of the Vim text editor. It's written by one of the authors of
 Documentation for these shortcuts is Coming Soon. For now, you can see all of the bindings provided by looking
 in the [source](https://github.com/philc/sheetkeys/blob/master/content_scripts/commands.js#L88).
 
-**Other UI improvements**
+### Change Cell Color
+
+| **Key Bind** |                **Color**                       | **Color Name**          |
+|:------------:|:----------------------------------------------:|-------------------------|
+| ;c\`00| ![](https://via.placeholder.com/15/000000/000000?text=+) | Black                   | 
+| ;c014 | ![](https://via.placeholder.com/15/434343/000000?text=+) | Dark Grey 4             |
+| ;c013 | ![](https://via.placeholder.com/15/666666/000000?text=+) | Dark Gray 3             |
+| ;c012 | ![](https://via.placeholder.com/15/999999/000000?text=+) | Dark Gray 2             |
+| ;c011 | ![](https://via.placeholder.com/15/b7b7b7/000000?text=+) | Dark Gray 1             |
+| ;c000 | ![](https://via.placeholder.com/15/cccccc/000000?text=+) | Gray                    |
+| ;c001 | ![](https://via.placeholder.com/15/d9d9d9/000000?text=+) | Light Gray 1            |
+| ;c002 | ![](https://via.placeholder.com/15/efefef/000000?text=+) | Light Gray 2            |
+| ;c003 | ![](https://via.placeholder.com/15/f3f3f3/000000?text=+) | Light Gray 3            |
+| ;c100 | ![](https://via.placeholder.com/15/ffffff/000000?text=+) | White                   |
+|       |                                                          |                         |
+| ;c200 | ![](https://via.placeholder.com/15/980000/000000?text=+) | RedBerry                |
+| ;c213 | ![](https://via.placeholder.com/15/5b0f00/000000?text=+) | Dark Red Berry 3        |
+| ;c212 | ![](https://via.placeholder.com/15/85200c/000000?text=+) | Dark Red Berry 2        |
+| ;c211 | ![](https://via.placeholder.com/15/a61c00/000000?text=+) | Dark Red Berry 1        |
+| ;c201 | ![](https://via.placeholder.com/15/cc4125/000000?text=+) | Light Red Berry 1       |
+| ;c202 | ![](https://via.placeholder.com/15/dd7e6b/000000?text=+) | Light Red Berry 2       |
+| ;c203 | ![](https://via.placeholder.com/15/e6b8af/000000?text=+) | Light Red Berry 3       |
+|       |                                                          |                         |
+| ;c300 | ![](https://via.placeholder.com/15/ff0000/000000?text=+) | Red                     |
+| ;c313 | ![](https://via.placeholder.com/15/660000/000000?text=+) | Dark Red 3              |
+| ;c312 | ![](https://via.placeholder.com/15/990000/000000?text=+) | Dark Red 2              |
+| ;c311 | ![](https://via.placeholder.com/15/cc0000/000000?text=+) | Dark Red 1              |
+| ;c301 | ![](https://via.placeholder.com/15/e06666/000000?text=+) | Light Red 1             |
+| ;c302 | ![](https://via.placeholder.com/15/ea9999/000000?text=+) | Light Red 2             |
+| ;c303 | ![](https://via.placeholder.com/15/f4cccc/000000?text=+) | Light Red 3             |
+|       |                                                          |                         |
+| ;c400 | ![](https://via.placeholder.com/15/ff9900/000000?text=+) | Orange                  |
+| ;c413 | ![](https://via.placeholder.com/15/783f04/000000?text=+) | Dark Orange 3           |
+| ;c412 | ![](https://via.placeholder.com/15/b45f06/000000?text=+) | Dark Orange 2           |
+| ;c411 | ![](https://via.placeholder.com/15/e69138/000000?text=+) | Dark Orange 1           |
+| ;c401 | ![](https://via.placeholder.com/15/f6b26b/000000?text=+) | Light Orange 1          |
+| ;c402 | ![](https://via.placeholder.com/15/f9cb9c/000000?text=+) | Light Orange 2          |
+| ;c403 | ![](https://via.placeholder.com/15/fce5cd/000000?text=+) | Light Orange 3          |
+|       |                                                          |                         |
+| ;c500 | ![](https://via.placeholder.com/15/ffff00/000000?text=+) | Yellow                  |
+| ;c513 | ![](https://via.placeholder.com/15/7f6000/000000?text=+) | Dark Yellow 3           |
+| ;c512 | ![](https://via.placeholder.com/15/bf9000/000000?text=+) | Dark Yellow 2           |
+| ;c511 | ![](https://via.placeholder.com/15/f1c232/000000?text=+) | Dark Yellow 1           |
+| ;c501 | ![](https://via.placeholder.com/15/ffd966/000000?text=+) | Light Yellow 1          |
+| ;c502 | ![](https://via.placeholder.com/15/ffe599/000000?text=+) | Light Yellow 2          |
+| ;c503 | ![](https://via.placeholder.com/15/fff2cc/000000?text=+) | Light Yellow 3          |
+|       |                                                          |                         |
+| ;c600 | ![](https://via.placeholder.com/15/00ff00/000000?text=+) | Green                   |
+| ;c613 | ![](https://via.placeholder.com/15/274e13/000000?text=+) | Dark Green 3            |
+| ;c612 | ![](https://via.placeholder.com/15/38761d/000000?text=+) | Dark Green 2            |
+| ;c611 | ![](https://via.placeholder.com/15/6aa84f/000000?text=+) | Dark Green 1            |
+| ;c601 | ![](https://via.placeholder.com/15/93c47d/000000?text=+) | Light Green 1           |
+| ;c602 | ![](https://via.placeholder.com/15/b6d7a8/000000?text=+) | Light Green 2           |
+| ;c603 | ![](https://via.placeholder.com/15/d9ead3/000000?text=+) | Light Green 3           |
+|       |                                                          |                         |                
+| ;c700 | ![](https://via.placeholder.com/15/00ffff/000000?text=+) | Cyan                    |
+| ;c713 | ![](https://via.placeholder.com/15/0c343d/000000?text=+) | Dark Cyan 3             |
+| ;c712 | ![](https://via.placeholder.com/15/134f5c/000000?text=+) | Dark Cyan 2             |
+| ;c711 | ![](https://via.placeholder.com/15/45818e/000000?text=+) | Dark Cyan 1             |
+| ;c701 | ![](https://via.placeholder.com/15/76a5af/000000?text=+) | Light Cyan 1            |
+| ;c702 | ![](https://via.placeholder.com/15/a2c4c9/000000?text=+) | Light Cyan 2            |
+| ;c703 | ![](https://via.placeholder.com/15/d0e0e3/000000?text=+) | Light Cyan 3            |
+|       |                                                          |                         |
+| ;c800 | ![](https://via.placeholder.com/15/4a86e8/000000?text=+) | CornFlower Blue         |
+| ;c813 | ![](https://via.placeholder.com/15/1c4587/000000?text=+) | Dark CornFlower Blue 3  |
+| ;c812 | ![](https://via.placeholder.com/15/1155cc/000000?text=+) | Dark CornFlower Blue 2  |
+| ;c811 | ![](https://via.placeholder.com/15/3c78d8/000000?text=+) | Dark CornFlower Blue 1  |
+| ;c801 | ![](https://via.placeholder.com/15/6d9eeb/000000?text=+) | Light CornFlower Blue 1 |
+| ;c802 | ![](https://via.placeholder.com/15/a4c2f4/000000?text=+) | Light CornFlower Blue 2 |
+| ;c803 | ![](https://via.placeholder.com/15/c9daf8/000000?text=+) | Light CornFlower Blue 3 |
+|       |                                                          |                         |
+| ;c900 | ![](https://via.placeholder.com/15/0000ff/000000?text=+) | Blue                    |
+| ;c913 | ![](https://via.placeholder.com/15/073763/000000?text=+) | Dark Blue 3             |
+| ;c912 | ![](https://via.placeholder.com/15/0b5394/000000?text=+) | Dark Blue 2             |
+| ;c911 | ![](https://via.placeholder.com/15/3d85c6/000000?text=+) | Dark Blue 1             |
+| ;c901 | ![](https://via.placeholder.com/15/6fa8dc/000000?text=+) | Light Blue 1            |
+| ;c902 | ![](https://via.placeholder.com/15/9fc5e8/000000?text=+) | Light Blue 2            |
+| ;c903 | ![](https://via.placeholder.com/15/cfe2f3/000000?text=+) | Light Blue 3            |
+|       |                                                          |                         |
+| ;c\-00| ![](https://via.placeholder.com/15/9900ff/000000?text=+) | Purple                  |
+| ;c\-13| ![](https://via.placeholder.com/15/20124d/000000?text=+) | Dark Purple 3           |
+| ;c\-12| ![](https://via.placeholder.com/15/351c75/000000?text=+) | Dark Purple 2           |
+| ;c\-11| ![](https://via.placeholder.com/15/674ea7/000000?text=+) | Dark Purple 1           |
+| ;c\-01| ![](https://via.placeholder.com/15/8e7cc3/000000?text=+) | Light Purple 1          |
+| ;c\-02| ![](https://via.placeholder.com/15/b4a7d6/000000?text=+) | Light Purple 2          |
+| ;c\-03| ![](https://via.placeholder.com/15/d9d2e9/000000?text=+) | Light Purple 3          |
+|       |                                                          |                         |
+| ;c=00 | ![](https://via.placeholder.com/15/ff00ff/000000?text=+) | Magenta                 |
+| ;c=13 | ![](https://via.placeholder.com/15/4c1130/000000?text=+) | Dark Magenta 3          |
+| ;c=12 | ![](https://via.placeholder.com/15/741b47/000000?text=+) | Dark Magenta 2          |
+| ;c=11 | ![](https://via.placeholder.com/15/a64d79/000000?text=+) | Dark Magenta 1          |
+| ;c=01 | ![](https://via.placeholder.com/15/c27ba0/000000?text=+) | Light Magenta 1         |
+| ;c=02 | ![](https://via.placeholder.com/15/d5a6bd/000000?text=+) | Light Magenta 2         |
+| ;c=03 | ![](https://via.placeholder.com/15/ead1dc/000000?text=+) | Light Magenta 3         |
+|       |                                                          |                         |                
+
+
+**Other|UI improvements**
 
 * In Google Sheets, when editing a cell, typing ESC erases all of the changes you've made, and your changes
   can't be brought back with "Undo". Sheetkeys fixes this. Now ESC will save your changes to the cell, and you

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ in the [source](https://github.com/philc/sheetkeys/blob/master/content_scripts/c
 |       |                                                          |                         |                
 
 
-**Other|UI improvements**
+**Other UI improvements**
 
 * In Google Sheets, when editing a cell, typing ESC erases all of the changes you've made, and your changes
   can't be brought back with "Undo". Sheetkeys fixes this. Now ESC will save your changes to the cell, and you

--- a/content_scripts/commands.js
+++ b/content_scripts/commands.js
@@ -68,16 +68,116 @@ Commands = {
     alignLeft: { fn: SheetActions.alignLeft.bind(SheetActions) },
     alignCenter: { fn: SheetActions.alignCenter.bind(SheetActions) },
     alignRight: { fn: SheetActions.alignRight.bind(SheetActions) },
-    colorCellWhite: { fn : SheetActions.colorCellWhite.bind(SheetActions) },
-    colorCellLightYellow3: { fn : SheetActions.colorCellLightYellow3.bind(SheetActions) },
-    colorCellLightCornflowerBlue3: { fn : SheetActions.colorCellLightCornflowerBlue3.bind(SheetActions) },
-    colorCellLightPurple: { fn : SheetActions.colorCellLightPurple.bind(SheetActions) },
-    colorCellLightRed3: { fn : SheetActions.colorCellLightRed3.bind(SheetActions) },
-    colorCellLightGray2: { fn : SheetActions.colorCellLightGray2.bind(SheetActions) },
-    fontSizeNormal: { fn : SheetActions.setFontSize10.bind(SheetActions) },
-    fontSizeSmall: { fn : SheetActions.setFontSize8.bind(SheetActions) },
+    fontSizeNormal: { fn: SheetActions.setFontSize10.bind(SheetActions) },
+    fontSizeSmall: { fn: SheetActions.setFontSize8.bind(SheetActions) },
     freezeRow: { fn: SheetActions.freezeRow.bind(SheetActions) },
     freezeColumn: { fn: SheetActions.freezeColumn.bind(SheetActions) },
+
+    // Color Cells
+    // You can find the names of these color swatches by hoverig over the swatches and seeing the tooltip.
+
+    // Black to White
+    colorCellBlack: { fn: () => SheetActions.colorCell.bind(SheetActions)('black') },
+    colorCellDarkGrey4: { fn: () => SheetActions.colorCell.bind(SheetActions)('dark gray 4') },
+    colorCellDarkGray3: { fn: () => SheetActions.colorCell.bind(SheetActions)('dark gray 3') },
+    colorCellDarkGray2: { fn: () => SheetActions.colorCell.bind(SheetActions)('dark gray 2') },
+    colorCellDarkGray1: { fn: () => SheetActions.colorCell.bind(SheetActions)('dark gray 1') },
+    colorCellGray: { fn: () => SheetActions.colorCell.bind(SheetActions)('gray') },
+    colorCellLightGray1: { fn: () => SheetActions.colorCell.bind(SheetActions)('light gray 1') },
+    colorCellLightGray2: { fn: () => SheetActions.colorCell.bind(SheetActions)('light gray 2') },
+    colorCellLightGray3: { fn: () => SheetActions.colorCell.bind(SheetActions)('light gray 3') },
+    colorCellWhite: { fn: () => SheetActions.colorCell.bind(SheetActions)('white') },
+
+    // Red Berry
+    colorCellRedBerry: { fn: () => SheetActions.colorCell.bind(SheetActions)('red berry') },
+    colorCellDarkRedBerry3: { fn: () => SheetActions.colorCell.bind(SheetActions)('dark red berry 3') },
+    colorCellDarkRedBerry2: { fn: () => SheetActions.colorCell.bind(SheetActions)('dark red berry 2') },
+    colorCellDarkRedBerry1: { fn: () => SheetActions.colorCell.bind(SheetActions)('dark red berry 1') },
+    colorCellLightRedBerry1: { fn: () => SheetActions.colorCell.bind(SheetActions)('light red berry 1') },
+    colorCellLightRedBerry2: { fn: () => SheetActions.colorCell.bind(SheetActions)('light red berry 2') },
+    colorCellLightRedBerry3: { fn: () => SheetActions.colorCell.bind(SheetActions)('light red berry 3') },
+
+    // Red
+    colorCellRed: { fn: () => SheetActions.colorCell.bind(SheetActions)('red') },
+    colorCellDarkRed3: { fn: () => SheetActions.colorCell.bind(SheetActions)('dark red 3') },
+    colorCellDarkRed2: { fn: () => SheetActions.colorCell.bind(SheetActions)('dark red 2') },
+    colorCellDarkRed1: { fn: () => SheetActions.colorCell.bind(SheetActions)('dark red 1') },
+    colorCellLightRed1: { fn: () => SheetActions.colorCell.bind(SheetActions)('light red 1') },
+    colorCellLightRed2: { fn: () => SheetActions.colorCell.bind(SheetActions)('light red 2') },
+    colorCellLightRed3: { fn: () => SheetActions.colorCell.bind(SheetActions)('light red 3') },
+
+    // Orange
+    colorCellOrange: { fn: () => SheetActions.colorCell.bind(SheetActions)('orange') },
+    colorCellDarkOrange3: { fn: () => SheetActions.colorCell.bind(SheetActions)('dark orange 3') },
+    colorCellDarkOrange2: { fn: () => SheetActions.colorCell.bind(SheetActions)('dark orange 2') },
+    colorCellDarkOrange1: { fn: () => SheetActions.colorCell.bind(SheetActions)('dark orange 1') },
+    colorCellLightOrange1: { fn: () => SheetActions.colorCell.bind(SheetActions)('light orange 1') },
+    colorCellLightOrange2: { fn: () => SheetActions.colorCell.bind(SheetActions)('light orange 2') },
+    colorCellLightOrange3: { fn: () => SheetActions.colorCell.bind(SheetActions)('light orange 3') },
+
+    // Yellow
+    colorCellYellow: { fn: () => SheetActions.colorCell.bind(SheetActions)('yellow') },
+    colorCellDarkYellow3: { fn: () => SheetActions.colorCell.bind(SheetActions)('dark yellow 3') },
+    colorCellDarkYellow2: { fn: () => SheetActions.colorCell.bind(SheetActions)('dark yellow 2') },
+    colorCellDarkYellow1: { fn: () => SheetActions.colorCell.bind(SheetActions)('dark yellow 1') },
+    colorCellLightYellow1: { fn: () => SheetActions.colorCell.bind(SheetActions)('light yellow 1') },
+    colorCellLightYellow2: { fn: () => SheetActions.colorCell.bind(SheetActions)('light yellow 2') },
+    colorCellLightYellow3: { fn: () => SheetActions.colorCell.bind(SheetActions)('light yellow 3') },
+
+    // Green
+    colorCellGreen: { fn: () => SheetActions.colorCell.bind(SheetActions)('green') },
+    colorCellDarkGreen3: { fn: () => SheetActions.colorCell.bind(SheetActions)('dark green 3') },
+    colorCellDarkGreen2: { fn: () => SheetActions.colorCell.bind(SheetActions)('dark green 2') },
+    colorCellDarkGreen1: { fn: () => SheetActions.colorCell.bind(SheetActions)('dark green 1') },
+    colorCellLightGreen1: { fn: () => SheetActions.colorCell.bind(SheetActions)('light green 1') },
+    colorCellLightGreen2: { fn: () => SheetActions.colorCell.bind(SheetActions)('light green 2') },
+    colorCellLightGreen3: { fn: () => SheetActions.colorCell.bind(SheetActions)('light green 3') },
+
+    // Cyan
+    colorCellCyan: { fn: () => SheetActions.colorCell.bind(SheetActions)('cyan') },
+    colorCellDarkCyan3: { fn: () => SheetActions.colorCell.bind(SheetActions)('dark cyan 3') },
+    colorCellDarkCyan2: { fn: () => SheetActions.colorCell.bind(SheetActions)('dark cyan 2') },
+    colorCellDarkCyan1: { fn: () => SheetActions.colorCell.bind(SheetActions)('dark cyan 1') },
+    colorCellLightCyan1: { fn: () => SheetActions.colorCell.bind(SheetActions)('light cyan 1') },
+    colorCellLightCyan2: { fn: () => SheetActions.colorCell.bind(SheetActions)('light cyan 2') },
+    colorCellLightCyan3: { fn: () => SheetActions.colorCell.bind(SheetActions)('light cyan 3') },
+
+    // Corn Flower Blue
+    colorCellCornFlowerBlue: { fn: () => SheetActions.colorCell.bind(SheetActions)('cornflower blue') },
+    colorCellDarkCornFlowerBlue3: { fn: () => SheetActions.colorCell.bind(SheetActions)('dark cornflower blue 3') },
+    colorCellDarkCornFlowerBlue2: { fn: () => SheetActions.colorCell.bind(SheetActions)('dark cornflower blue 2') },
+    colorCellDarkCornFlowerBlue1: { fn: () => SheetActions.colorCell.bind(SheetActions)('dark cornflower blue 1') },
+    colorCellLightCornFlowerBlue1: { fn: () => SheetActions.colorCell.bind(SheetActions)('light cornflower blue 1') },
+    colorCellLightCornFlowerBlue2: { fn: () => SheetActions.colorCell.bind(SheetActions)('light cornflower blue 2') },
+    colorCellLightCornFlowerBlue3: { fn: () => SheetActions.colorCell.bind(SheetActions)('light cornflower blue 3') },
+
+    // Blue
+    colorCellBlue: { fn: () => SheetActions.colorCell.bind(SheetActions)('blue') },
+    colorCellDarkBlue3: { fn: () => SheetActions.colorCell.bind(SheetActions)('dark blue 3') },
+    colorCellDarkBlue2: { fn: () => SheetActions.colorCell.bind(SheetActions)('dark blue 2') },
+    colorCellDarkBlue1: { fn: () => SheetActions.colorCell.bind(SheetActions)('dark blue 1') },
+    colorCellLightBlue1: { fn: () => SheetActions.colorCell.bind(SheetActions)('light blue 1') },
+    colorCellLightBlue2: { fn: () => SheetActions.colorCell.bind(SheetActions)('light blue 2') },
+    colorCellLightBlue3: { fn: () => SheetActions.colorCell.bind(SheetActions)('light blue 3') },
+
+    // Purple
+    colorCellPurple: { fn: () => SheetActions.colorCell.bind(SheetActions)('purple') },
+    colorCellDarkPurple3: { fn: () => SheetActions.colorCell.bind(SheetActions)('dark purple 3') },
+    colorCellDarkPurple2: { fn: () => SheetActions.colorCell.bind(SheetActions)('dark purple 2') },
+    colorCellDarkPurple1: { fn: () => SheetActions.colorCell.bind(SheetActions)('dark purple 1') },
+    colorCellLightPurple1: { fn: () => SheetActions.colorCell.bind(SheetActions)('light purple 1') },
+    colorCellLightPurple2: { fn: () => SheetActions.colorCell.bind(SheetActions)('light purple 2') },
+    colorCellLightPurple3: { fn: () => SheetActions.colorCell.bind(SheetActions)('light purple 3') },
+
+    // Magenta
+    colorCellMagenta: { fn: () => SheetActions.colorCell.bind(SheetActions)('magenta') },
+    colorCellDarkMagenta3: { fn: () => SheetActions.colorCell.bind(SheetActions)('dark magenta 3') },
+    colorCellDarkMagenta2: { fn: () => SheetActions.colorCell.bind(SheetActions)('dark magenta 2') },
+    colorCellDarkMagenta1: { fn: () => SheetActions.colorCell.bind(SheetActions)('dark magenta 1') },
+    colorCellLightMagenta1: { fn: () => SheetActions.colorCell.bind(SheetActions)('light magenta 1') },
+    colorCellLightMagenta2: { fn: () => SheetActions.colorCell.bind(SheetActions)('light magenta 2') },
+    colorCellLightMagenta3: { fn: () => SheetActions.colorCell.bind(SheetActions)('light magenta 3') },
+
 
     // Misc
     toggleFullScreen: { fn: SheetActions.toggleFullScreen.bind(SheetActions) },
@@ -153,16 +253,114 @@ Commands = {
       ";,a,l": "alignLeft",
       ";,a,c": "alignCenter",
       ";,a,r": "alignRight",
-      ";,c,w": "colorCellWhite",
-      ";,c,y": "colorCellLightYellow3",
-      ";,c,b": "colorCellLightCornflowerBlue3",
-      ";,c,p": "colorCellLightPurple",
-      ";,c,r": "colorCellLightRed3",
-      ";,c,g": "colorCellLightGray2",
       ";,f,n": "fontSizeNormal",
       ";,f,s": "fontSizeSmall",
       ";,f,r": "freezeRow",
       ";,f,c": "freezeColumn",
+
+      // Cell Colors
+      // Black to White
+      ";,c,`,0,0": "colorCellBlack",
+      ";,c,0,1,4": "colorCellDarkGrey4",
+      ";,c,0,1,3": "colorCellDarkGray3",
+      ";,c,0,1,2": "colorCellDarkGray2",
+      ";,c,0,1,1": "colorCellDarkGray1",
+      ";,c,0,0,0": "colorCellGray",
+      ";,c,0,0,1": "colorCellLightGray1",
+      ";,c,0,0,2": "colorCellLightGray2",
+      ";,c,0,0,3": "colorCellLightGray3",
+      ";,c,1,0,0": "colorCellWhite",
+
+      // Red Berry
+      ";,c,2,0,0": "colorCellRedBerry",
+      ";,c,2,1,3": "colorCellDarkRedBerry3",
+      ";,c,2,1,2": "colorCellDarkRedBerry2",
+      ";,c,2,1,1": "colorCellDarkRedBerry1",
+      ";,c,2,0,1": "colorCellLightRedBerry1",
+      ";,c,2,0,2": "colorCellLightRedBerry2",
+      ";,c,2,0,3": "colorCellLightRedBerry3",
+
+      // Red
+      ";,c,3,0,0": "colorCellRed",
+      ";,c,3,1,3": "colorCellDarkRed3",
+      ";,c,3,1,2": "colorCellDarkRed2",
+      ";,c,3,1,1": "colorCellDarkRed1",
+      ";,c,3,0,1": "colorCellLightRed1",
+      ";,c,3,0,2": "colorCellLightRed2",
+      ";,c,3,0,3": "colorCellLightRed3",
+
+      // Orange
+      ";,c,4,0,0": "colorCellOrange",
+      ";,c,4,1,3": "colorCellDarkOrange3",
+      ";,c,4,1,2": "colorCellDarkOrange2",
+      ";,c,4,1,1": "colorCellDarkOrange1",
+      ";,c,4,0,1": "colorCellLightOrange1",
+      ";,c,4,0,2": "colorCellLightOrange2",
+      ";,c,4,0,3": "colorCellLightOrange3",
+
+      // Yellow
+      ";,c,5,0,0": "colorCellYellow",
+      ";,c,5,1,3": "colorCellDarkYellow3",
+      ";,c,5,1,2": "colorCellDarkYellow2",
+      ";,c,5,1,1": "colorCellDarkYellow1",
+      ";,c,5,0,1": "colorCellLightYellow1",
+      ";,c,5,0,2": "colorCellLightYellow2",
+      ";,c,5,0,3": "colorCellLightYellow3",
+
+      // Green
+      ";,c,6,0,0": "colorCellGreen",
+      ";,c,6,1,3": "colorCellDarkGreen3",
+      ";,c,6,1,2": "colorCellDarkGreen2",
+      ";,c,6,1,1": "colorCellDarkGreen1",
+      ";,c,6,0,1": "colorCellLightGreen1",
+      ";,c,6,0,2": "colorCellLightGreen2",
+      ";,c,6,0,3": "colorCellLightGreen3",
+
+      // Cyan
+      ";,c,7,0,0": "colorCellCyan",
+      ";,c,7,1,3": "colorCellDarkCyan3",
+      ";,c,7,1,2": "colorCellDarkCyan2",
+      ";,c,7,1,1": "colorCellDarkCyan1",
+      ";,c,7,0,1": "colorCellLightCyan1",
+      ";,c,7,0,2": "colorCellLightCyan2",
+      ";,c,7,0,3": "colorCellLightCyan3",
+
+      // Corn Flower Blue
+      ";,c,8,0,0": "colorCellCornFlowerBlue",
+      ";,c,8,1,3": "colorCellDarkCornFlowerBlue3",
+      ";,c,8,1,2": "colorCellDarkCornFlowerBlue2",
+      ";,c,8,1,1": "colorCellDarkCornFlowerBlue1",
+      ";,c,8,0,1": "colorCellLightCornFlowerBlue1",
+      ";,c,8,0,2": "colorCellLightCornFlowerBlue2",
+      ";,c,8,0,3": "colorCellLightCornFlowerBlue3",
+
+      // Blue
+      ";,c,9,0,0": "colorCellBlue",
+      ";,c,9,1,3": "colorCellDarkBlue3",
+      ";,c,9,1,2": "colorCellDarkBlue2",
+      ";,c,9,1,1": "colorCellDarkBlue1",
+      ";,c,9,0,1": "colorCellLightBlue1",
+      ";,c,9,0,2": "colorCellLightBlue2",
+      ";,c,9,0,3": "colorCellLightBlue3",
+
+      // Purple
+      ";,c,-,0,0": "colorCellPurple",
+      ";,c,-,1,3": "colorCellDarkPurple3",
+      ";,c,-,1,2": "colorCellDarkPurple2",
+      ";,c,-,1,1": "colorCellDarkPurple1",
+      ";,c,-,0,1": "colorCellLightPurple1",
+      ";,c,-,0,2": "colorCellLightPurple2",
+      ";,c,-,0,3": "colorCellLightPurple3",
+
+      // Magenta
+      ";,c,=,0,0": "colorCellMagenta",
+      ";,c,=,1,3": "colorCellDarkMagenta3",
+      ";,c,=,1,2": "colorCellDarkMagenta2",
+      ";,c,=,1,1": "colorCellDarkMagenta1",
+      ";,c,=,0,1": "colorCellLightMagenta1",
+      ";,c,=,0,2": "colorCellLightMagenta2",
+      ";,c,=,0,3": "colorCellLightMagenta3",
+
 
       // Misc
       ";,w,m": "toggleFullScreen", // Mnemonic for "window maximize"

--- a/content_scripts/sheet_actions.js
+++ b/content_scripts/sheet_actions.js
@@ -39,16 +39,6 @@ SheetActions = {
     wrap: ["Text wrapping", "Wrap"]
   },
 
-  // You can find the names of these color swatches by hoverig over the swatches and seeing the tooltip.
-  colors: {
-    white: "white",
-    lightYellow3: "light yellow 3",
-    lightCornflowBlue3: "light cornflower blue 3",
-    lightPurple3: "light purple 3",
-    lightRed3: "light red 3",
-    lightGray2: "light gray 2"
-  },
-
   // A mapping of button-caption to DOM element.
   menuItemElements: {},
 
@@ -470,12 +460,9 @@ SheetActions = {
   alignLeft() { this.clickToolbarButton(this.buttons.left); },
   alignCenter() { this.clickToolbarButton(this.buttons.center); },
   alignRight() { this.clickToolbarButton(this.buttons.right); },
-  colorCellWhite() { this.changeCellColor(this.colors.white); },
-  colorCellLightYellow3() { this.changeCellColor(this.colors.lightYellow3); },
-  colorCellLightCornflowerBlue3() { this.changeCellColor(this.colors.lightCornflowBlue3); },
-  colorCellLightPurple() { this.changeCellColor(this.colors.lightPurple3); },
-  colorCellLightRed3() { this.changeCellColor(this.colors.lightRed3); },
-  colorCellLightGray2() { this.changeCellColor(this.colors.lightGray2); },
+
+  // Cell Color
+  colorCell(color) { this.changeCellColor(color); },
 
   freezeRow() {
     this.clickMenu(this.menuItems.freeze); // This forces the creation of the sub-menu items.

--- a/content_scripts/ui.js
+++ b/content_scripts/ui.js
@@ -19,7 +19,7 @@ const addOneTimeListener = function(dispatcher, eventType, listenerFn) {
 
 UI = {
   // An arbitrary limit that should instead be equal to the longest key sequence that's actually bound.
-  maxBindingLength: 3,
+  maxBindingLength: 6,
   // Mode can be one of:
   // * normal
   // * insert: when editing a cell's contents


### PR DESCRIPTION
I thought the cell color options was limited so added more cell color options 😃 

Also I felt like the `colorCell"Color"` functions can be concluded into a single function, so concluded all of those into a new single `colorCell` function and removed no-more-useful code.

And lastly increased `maxKeyBindLength` to accommodate new cell color key bindings.

Hoping to see this come as a official chrome extension or a sheets add-on if that's possible 

-- Cheers 

