### PR TITLE
Add command repeat (like Vim's `:h count`)

### DIFF
--- a/content_scripts/ui.js
+++ b/content_scripts/ui.js
@@ -219,10 +219,6 @@ const UI = {
         this.keyQueue = [];
         this.cancelEvent(e);
 
-        if (commandName == "undo" || commandName == "redo") {
-          this.repeatCount = this.previousRepeatCount || 1;
-        }
-
         if (this.repeatCount === null) {
           this.repeatCount = 1;
         }
@@ -230,7 +226,6 @@ const UI = {
         for (let i = 0; i < this.repeatCount; i++) {
           Commands.commands[commandName].fn();
         }
-        this.previousRepeatCount = this.repeatCount;
         this.repeatCount = null;
       }
     }

--- a/content_scripts/ui.js
+++ b/content_scripts/ui.js
@@ -187,6 +187,9 @@ const UI = {
         this.repeatCount = parseInt(keyString);
       } else {
         this.repeatCount = this.repeatCount * 10 + parseInt(keyString);
+        if (this.repeatCount > 99) {
+          this.repeatCount = 99;
+        }
       }
       // console.log("repeatCount:", this.repeatCount);
       this.cancelEvent(e);


### PR DESCRIPTION
This is close to a minimal functional implementation of command repeating, similar to Vim's concept of a count. It builds on the work by @KiLLeRRaT in #23, by rebasing and incorporating the feedback from that pull request. Any feedback is welcome.

I'm fairly happy with how things are working now, but I have two main gripes:
1. Not all commands make sense with a count, e.g. `i`; for example, `5i` for some reason navigates down 2 cells and then enters insert mode, while `4i` navigates down 2 cells and _doesn't_ enter insert mode. I'm guessing it's an "enter-exit-enter-exit" kind of thing, such that the parity of the count decides which state it ends up in. In any case, I think this is confusing behaviour. A possible remedy would be to store a boolean somewhere (maybe in `commands.js`?) which decides whether a command is allowed to be repeated; there may be many others which also produce confusing behaviour, and this would let us decide that case-by-case. I would be happy to implement this or something similar, but thought I'd leave that for another pull request.
2. It takes a long time to execute many repeats. This was mentioned in #23, and so here I've implemented a cap of 99 repeats (the value is just clamped); but this feels a bit unsatisfactory to me, especially for movement commands. The main time that I reach for counts is when I want to e.g. scroll down 50 rows, so I do `50j`. My Vim-brain expects this to be instant, but of course in sheetkeys this causes a loop which triggers 50 consecutive `j` key events, so it takes over a second. I don't really know how to solve this though; it might just be impossible with the current model in sheetkeys (or impossible in general). Oh well.

Closes #1 
Supersedes #23 