### PR TITLE
Load the toolbar merge submenu before sending merge commands

### DIFF
--- a/content_scripts/sheet_actions.js
+++ b/content_scripts/sheet_actions.js
@@ -458,15 +458,23 @@ const SheetActions = {
 
   // Merging cells
   mergeAllCells() {
+    // This call is so that the merge types are loaded. Fills a similar function to activateMenu.
+    this.clickToolbarButton(["Select merge type"])
     this.clickMenu(this.menuItems.mergeAll);
   },
   mergeCellsHorizontally() {
+    // This call is so that the merge types are loaded. Fills a similar function to activateMenu.
+    this.clickToolbarButton(["Select merge type"])
     this.clickMenu(this.menuItems.mergeHorizontally);
   },
   mergeCellsVertically() {
+    // This call is so that the merge types are loaded. Fills a similar function to activateMenu.
+    this.clickToolbarButton(["Select merge type"])
     this.clickMenu(this.menuItems.mergeVertically);
   },
   unmergeCells() {
+    // This call is so that the merge types are loaded. Fills a similar function to activateMenu.
+    this.clickToolbarButton(["Select merge type"])
     this.clickMenu(this.menuItems.unmerge);
   },
 


### PR DESCRIPTION
Sometimes the "Merge all", "Merge vertically", etc. menu options wouldn't be loaded, so the shortcut wouldn't work. This change loads the toolbar merge submenu before attempting to merge, which seems to fix this problem reliably.

Fixes #37 