### PR TITLE
Fix first input after page load being eaten

### DIFF
--- a/content_scripts/ui.js
+++ b/content_scripts/ui.js
@@ -224,7 +224,8 @@ const UI = {
 
         const command = Commands.commands[commandName];
 
-        if (this.repeatCount === null || command.nonRepeatable) {
+        // Note: use of == to check for either undefined or null
+        if (this.repeatCount == null || command.nonRepeatable) {
           this.repeatCount = 1;
         }
 


### PR DESCRIPTION
Fixes #46 

Use `==` instead of `===` when checking if we have a repeat count.
This is because on first page load, `this.repeatCount` will be `undefined`. With `===`, the first input on page load is eaten; with `==`, the logic works correctly.