### PR TITLE
Implement hashmark link support for `openCellAsUrl` in calls to `HYPERLINK`

### DIFF
--- a/content_scripts/sheet_actions.js
+++ b/content_scripts/sheet_actions.js
@@ -730,10 +730,23 @@ const SheetActions = {
       });
     } else {
       const text = formulaBar.textContent.trim();
-      const functionMatch = text.match(/HYPERLINK\("(.+?)"[^"]+".+?"\)/i);
-      // Case 2: Usage of the 'HYPERLINK("url", "caption")' function
+      const functionMatch = text.match(/HYPERLINK\("(.+?)"/i);
+      // Case 2: Usage of the 'HYPERLINK()' function
       if (functionMatch) {
-        window.open(functionMatch[1], "_blank");
+        const hashMatch = functionMatch[1].match(/^#/);
+        if (hashMatch) {
+          // It's a hashmark link, intended to move to a section on this page;
+          // so set the current page's hash to be this new hash.
+          window.location.hash = functionMatch[1];
+
+          // For some reason, we have to commit cell changes here;
+          // otherwise if changing the hash moves to a different cell,
+          // the new cell will be selected in insert mode.
+          this.commitCellChanges();
+        } else {
+          // Assume it's an external link, and open it in a new tab.
+          window.open(functionMatch[1], "_blank");
+        }
       } else {
         const urlMatches = text.match(/(https?:\/\/[^\s]+)/g);
         // Case 3: Raw link(s) in the cell's plain text


### PR DESCRIPTION
If the URL argument to a call to `HYPERLINK` begins with a hash (`#`), then change the current page's hash to equal the given hash; otherwise open the link in a new tab as normal.

I changed the regex (used for `functionMatch`) to be more permissive, because the `link_label` argument to `HYPERLINK` is optional. This is a bug, which causes the behaviour shown in #34 (should have opened the sheet in a new tab, with the new hash); but also caused links with any label other than a string literal (i.e. any links with indirect references) to not be openable with the `;o` action.
Possibly the regex is now too permissive, as it will work on some malformed formulae; but this seems like a small issue or non-issue to me.

Also, I'm not 100% sure why I have to call `this.commitCellChanges()` twice? I haven't read that function in great detail though, and it's probable that it's dependent on some state which is changed by assigning `window.location.hash = functionMatch[1]` above. The extra call should probably be removable with some further investigation.

Fixes #34 