### PR TITLE
added commands for ctrl+arrow navigation

### DIFF
--- a/content_scripts/commands.js
+++ b/content_scripts/commands.js
@@ -7,6 +7,27 @@ const Commands = {
   // in this map.
   commands: {
     // Cursor movement
+
+moveToLastNonEmptyInRow: {
+  fn: SheetActions.moveToLastNonEmptyInRow.bind(SheetActions),
+  name: "Move to last non-empty cell in row",
+  group: "movement",
+},
+moveToFirstNonEmptyInRow: {
+  fn: SheetActions.moveToFirstNonEmptyInRow.bind(SheetActions),
+  name: "Move to first non-empty cell in row",
+  group: "movement",
+},
+moveToTopNonEmptyInColumn: {
+  fn: SheetActions.moveToTopNonEmptyInColumn.bind(SheetActions),
+  name: "Move to top non-empty cell in column",
+  group: "movement",
+},
+moveToBottomNonEmptyInColumn: {
+  fn: SheetActions.moveToBottomNonEmptyInColumn.bind(SheetActions),
+  name: "Move to bottom non-empty cell in column",
+  group: "movement",
+},
     moveUp: {
       fn: SheetActions.moveUp.bind(SheetActions),
       name: "Move up",
@@ -386,6 +407,10 @@ const Commands = {
 
   defaultMappings: {
     "normal": {
+      "moveToLastNonEmptyInRow": "<A-l>",
+      "moveToFirstNonEmptyInRow": "<A-h>",
+      "moveToTopNonEmptyInColumn": "<A-k>",
+      "moveToBottomNonEmptyInColumn": "<A-j>",
       // Cursor movement
       "moveUp": "k",
       "moveDown": "j",

--- a/content_scripts/sheet_actions.js
+++ b/content_scripts/sheet_actions.js
@@ -310,6 +310,22 @@ const SheetActions = {
   //
   // Movement
   //
+    moveToLastNonEmptyInRow() {
+      this.typeKeyFn(KeyboardUtils.keyCodes.right, { control: true });
+    },
+
+    moveToFirstNonEmptyInRow() {
+      this.typeKeyFn(KeyboardUtils.keyCodes.left, { control: true });
+    },
+
+    moveToTopNonEmptyInColumn() {
+      this.typeKeyFn(KeyboardUtils.keyCodes.up, { control: true });
+    },
+
+    moveToBottomNonEmptyInColumn() {
+      this.typeKeyFn(KeyboardUtils.keyCodes.down, { control: true });
+    },
+
   moveUp() {
     const keyOptions = (this.mode == "normal") ? {} : { shift: true };
     this.typeKeyFn(KeyboardUtils.keyCodes.up, keyOptions);


### PR DESCRIPTION
Ctrl+arrow keys navigation has been mapped to alt+h/j/k/l.
Ctrl+arrow lets you navigate to last or first non-empty cell in a row or column. This navigation is handy when moving across isolated tables or across entire table. Closes #57